### PR TITLE
Clarify how to update data within Synology Photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,15 @@ There are three levels of authentication for the APIs, see the `authLevel` in th
 | --- | --- | 
 | SYNO.Foto.BackgroundTask.File | | 
 | SYNO.Foto.BackgroundTask.Info | | 
-| SYNO.Foto.Browse.Album | Browse albums. Normal and condition(al) albums are listed. | 
+| SYNO.Foto.Browse.Album | Handle albums. Normal and condition(al) albums are listed. | 
 | SYNO.Foto.Browse.Category | | 
-| SYNO.Foto.Browse.ConditionAlbum | Browse only condition(al) albums. | 
+| SYNO.Foto.Browse.ConditionAlbum | Handle only condition(al) albums. | 
 | SYNO.Foto.Browse.Diff | | 
-| SYNO.Foto.Browse.Folder | Browse only folders in the `Personal Space`. | 
+| SYNO.Foto.Browse.Folder | Handle only folders in the `Personal Space`. | 
 | SYNO.Foto.Browse.GeneralTag | | 
 | SYNO.Foto.Browse.Geocoding | | 
-| SYNO.Foto.Browse.Item | Browse/list items in folders in `Personal Space`. | 
-| SYNO.Foto.Browse.NormalAlbum | Browse only normal albums. | 
+| SYNO.Foto.Browse.Item | Handle an item in the `Personal Space`. Example methods include `add_tag`, `copy`, `delete`, `get`, `get_exif`, `get_tag`, `list`, `move`, `rename`, `set` | 
+| SYNO.Foto.Browse.NormalAlbum | Handle only normal albums. | 
 | SYNO.Foto.Browse.Person | | 
 | SYNO.Foto.Browse.RecentlyAdded | | 
 | SYNO.Foto.Browse.Timeline | | 
@@ -139,10 +139,10 @@ There are three levels of authentication for the APIs, see the `authLevel` in th
 | --- | --- | 
 | SYNO.FotoTeam.BackgroundTask.File | | 
 | SYNO.FotoTeam.Browse.Diff | | 
-| SYNO.FotoTeam.Browse.Folder | Browse only folders in the `Personal Space`. | 
+| SYNO.FotoTeam.Browse.Folder | Handle only folders in the `Shared Space`. | 
 | SYNO.FotoTeam.Browse.GeneralTag | | 
 | SYNO.FotoTeam.Browse.Geocoding | | 
-| SYNO.FotoTeam.Browse.Item | Browse/list items in folders in the `Personal Space`. | 
+| SYNO.FotoTeam.Browse.Item | Handle an item in the `Shared Space`. Example methods include `add_tag`, `copy`, `delete`, `get`, `get_exif`, `get_tag`, `list`, `move`, `rename`, `set` | 
 | SYNO.FotoTeam.Browse.Person | | 
 | SYNO.FotoTeam.Browse.RecentlyAdded | | 
 | SYNO.FotoTeam.Browse.Timeline | | 


### PR DESCRIPTION
A few changes here:
- The `FotoTeam` APIs said "Personal Space". Based on the other text in the readme, I'm assuming you meant "Shared Space". I didn't make the API calls to verify as it seems like a safe assumption
- Change "Browse" to "Handle". These APIs do quite a bit more than just readonly operations, but it took me awhile to figure that out
- List some example methods on `Browse.Item`. Makes it clearer that each API has a variety of read and write methods. Even if it's just some of the methods for a single API, giving an example lets people know there's more to go looking for to get a full picture of what these APIs do