### PR TITLE
Replace call to album's HTML page with SYNO.Core.Sharing.Login API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,11 +313,10 @@ This displays a shared album without having to be logged in (as long there's not
 These are the steps, how to get access on each file in a shared album:
 
 ### Getting a sharing_id
-The only way to get a valid cookie I know at the moment, is by using curl to call the link for the shared album. `-c cookie` stores the cookie data into the file `cookie`.
+We need to obtain a `sharing_sid` cookie value for subsequent requests. `-c cookie` stores the cookie data into the file `cookie`.
 ```
-curl -c cookie https://<IP_ADDRESS>/photo/mo/sharing/EkPUCJLDI
+curl -c cookie https://<IP_ADDRESS>/photo/webapi/entry.cgi -d 'api=SYNO.Core.Sharing.Login&method=login&version=1&sharing_id=EkPUCJLDI
 ```
-There should be another way via the AUTH.API.
 
 ### List items in a shared album
 Now we can list the items of this album with the following curl command:


### PR DESCRIPTION
Hi @zeichensatz.

First of all thanks for sharing your work on this undocumented API. It got me started with my own two projects using Synology Photos (shameless self-advertising: [synology-photos-slideshow](https://github.com/Caleb9/synology-photos-slideshow) for a digital-photo-frame project, and [SynologyPhotosUtil](https://github.com/Caleb9/SynologyPhotosUtil) for managing some tasks in Synology Photos).

Anyway I went through the same hurdle as you did to obtain the Shared Album cookie by just calling the HTML link which downloads entire JS client which is unnecessary e.g. when the app is not running in a browser. Somehow I managed to figure out that there actually is an API which returns both the `sharing_sid` cookie and JSON content containing the value as well - the `SYNO.Core.Sharing.Login` API. What led me to this discovery was trying to load a password protected public album in a signed-out browser using the sharing link.

This PR contains an update to your guide in README replacing the call to HTML page with API call.

It would still be useful to find out how to obtain `sharing_sid` when the share link is password protected, but so far I failed to figure it out. Inspecting the browser traffic, the official client first obtains a public key from the API, and then uses it to encrypt the password using RSA and/or AES - but that's a riddle for another time.
 
Hope you'll find this stuff useful, and also that Synology will one day finally give us official documentation for Photos API :).

Cheers!